### PR TITLE
PaissaDB: Implement Ward & Plot filter

### DIFF
--- a/src/views/paissa/FilterIconGrid.vue
+++ b/src/views/paissa/FilterIconGrid.vue
@@ -50,11 +50,11 @@ function onClickOutside() {
     <div class="dropdown-menu" id="dropdown-menu" role="menu">
       <div class="dropdown-content">
         <div class="dropdown-item">
-          <div style="width: 440px">
+          <div class="grid-container">
             <button
               v-for="option in options"
-              style="width: 40px"
-              :class="['button mr-1 mb-1', selected.includes(option.value) ? 'is-primary' : '']"
+              class="grid-button button mr-1 mb-1"
+              :class="{'is-primary': selected.includes(option.value)}"
               @click="onButtonClick($event, option.value)"
             >
               {{ option.label }}
@@ -65,3 +65,14 @@ function onClickOutside() {
     </div>
   </div>
 </template>
+
+<style scoped>
+/* this is hardcoded for 10 buttons wide, which is fine since this is only used in ward/plot filters */
+.grid-container {
+  width: 440px;
+}
+
+.grid-button {
+  width: 40px;
+}
+</style>

--- a/src/views/paissa/FilterIconGrid.vue
+++ b/src/views/paissa/FilterIconGrid.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import type {FilterOption} from "@/views/paissa/filters";
+import clickOutside from "click-outside-vue3";
+import {defineProps, ref} from "vue";
+
+// setup
+const props = defineProps<{
+  options: FilterOption<number>[];
+  selected: number[];
+}>();
+const emit = defineEmits<{
+  (e: "selectionChanged", selectedOptions: number[]): void;
+}>();
+const vClickOutside = clickOutside.directive;
+
+// state
+const isExpanded = ref(false);
+
+// methods
+function onCheckboxChange(event: any, value: number) {
+  const selectedOptions = new Set<number>(props.selected);
+  if (event.currentTarget.checked) {
+    selectedOptions.add(value);
+  } else {
+    selectedOptions.delete(value);
+  }
+  emit("selectionChanged", Array.from(selectedOptions));
+}
+
+function onClick() {
+  isExpanded.value = true;
+}
+
+function onClickOutside() {
+  isExpanded.value = false;
+}
+</script>
+
+<template>
+  <div class="dropdown" :class="{'is-active': isExpanded}" @click="onClick" v-click-outside="onClickOutside">
+    <div class="dropdown-trigger">
+      <!-- dropdown controller = filter button -->
+      <span class="icon m-0 is-clickable" aria-haspopup="true" aria-controls="dropdown-menu">
+        <font-awesome-icon :icon="['fas', 'filter']" />
+        {{ selected.length ? selected.length : null }}
+      </span>
+    </div>
+
+    <div class="dropdown-menu" id="dropdown-menu" role="menu">
+      <div class="dropdown-content">
+        <div class="dropdown-item" v-for="option in options" :key="option.value">
+          <label class="checkbox">
+            <input
+              type="checkbox"
+              :checked="selected.includes(option.value)"
+              @change="onCheckboxChange($event, option.value)"
+            />
+            {{ option.label }}
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/views/paissa/FilterIconGrid.vue
+++ b/src/views/paissa/FilterIconGrid.vue
@@ -51,11 +51,10 @@ function onClickOutside() {
       <div class="dropdown-content">
         <div class="dropdown-item">
           <div style="width: 440px">
-            <button v-for="option in options"
+            <button
+              v-for="option in options"
               style="width: 40px"
-              :class="['button mr-1 mb-1',
-                (selected.includes(option.value) ? 'is-primary' : '')
-              ]"
+              :class="['button mr-1 mb-1', selected.includes(option.value) ? 'is-primary' : '']"
               @click="onButtonClick($event, option.value)"
             >
               {{ option.label }}

--- a/src/views/paissa/FilterIconGrid.vue
+++ b/src/views/paissa/FilterIconGrid.vue
@@ -17,12 +17,13 @@ const vClickOutside = clickOutside.directive;
 const isExpanded = ref(false);
 
 // methods
-function onCheckboxChange(event: any, value: number) {
+function onButtonClick(event: any, value: number) {
   const selectedOptions = new Set<number>(props.selected);
-  if (event.currentTarget.checked) {
-    selectedOptions.add(value);
-  } else {
+
+  if (selectedOptions.has(value)) {
     selectedOptions.delete(value);
+  } else {
+    selectedOptions.add(value);
   }
   emit("selectionChanged", Array.from(selectedOptions));
 }
@@ -48,15 +49,18 @@ function onClickOutside() {
 
     <div class="dropdown-menu" id="dropdown-menu" role="menu">
       <div class="dropdown-content">
-        <div class="dropdown-item" v-for="option in options" :key="option.value">
-          <label class="checkbox">
-            <input
-              type="checkbox"
-              :checked="selected.includes(option.value)"
-              @change="onCheckboxChange($event, option.value)"
-            />
-            {{ option.label }}
-          </label>
+        <div class="dropdown-item">
+          <div style="width: 440px">
+            <button v-for="option in options"
+              style="width: 40px"
+              :class="['button mr-1 mb-1',
+                (selected.includes(option.value) ? 'is-primary' : '')
+              ]"
+              @click="onButtonClick($event, option.value)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/views/paissa/WorldView.vue
+++ b/src/views/paissa/WorldView.vue
@@ -244,12 +244,34 @@ onMounted(() => {
         <tr>
           <th>
             <span class="icon-text">
-              <span>Address</span>
+              <span>District</span>
               <FilterIcon
                 class="ml-1"
                 :options="filters.districts.options"
                 :selected="getSelectedFilterOptions('districts')"
                 @selectionChanged="onFilterSelectionChange('districts', $event)"
+              />
+            </span>
+          </th>
+          <th>
+            <span class="icon-text">
+              <span>Ward</span>
+              <FilterIcon
+                class="ml-1"
+                :options="filters.wards.options"
+                :selected="getSelectedFilterOptions('wards')"
+                @selectionChanged="onFilterSelectionChange('wards', $event)"
+              />
+            </span>
+          </th>
+          <th>
+            <span class="icon-text">
+              <span>Plot</span>
+              <FilterIcon
+                class="ml-1"
+                :options="filters.plots.options"
+                :selected="getSelectedFilterOptions('plots')"
+                @selectionChanged="onFilterSelectionChange('plots', $event)"
               />
             </span>
           </th>
@@ -348,10 +370,9 @@ onMounted(() => {
           v-for="plot in currentPagePlots"
           :key="[plot.world_id, plot.district_id, plot.ward_number, plot.plot_number].toString()"
         >
-          <td>
-            {{ client.districtName(plot.district_id) }}, Ward {{ plot.ward_number + 1 }}, Plot
-            {{ plot.plot_number + 1 }}
-          </td>
+          <td>{{ client.districtName(plot.district_id) }}</td>
+          <td>{{ plot.ward_number + 1 }}</td>
+          <td>{{ plot.plot_number + 1 }}</td>
           <td>{{ utils.sizeStr(plot.size) }}</td>
           <td>{{ plot.price.toLocaleString() }}</td>
           <td>

--- a/src/views/paissa/WorldView.vue
+++ b/src/views/paissa/WorldView.vue
@@ -3,6 +3,7 @@ import FlashOnChange from "@/components/FlashOnChange.vue";
 import TimeDisplay from "@/components/TimeDisplay.vue";
 import type {PaissaClient} from "@/views/paissa/client";
 import FilterIcon from "@/views/paissa/FilterIcon.vue";
+import FilterIconGrid from "@/views/paissa/FilterIconGrid.vue";
 import {filters} from "@/views/paissa/filters";
 import {addressSorter, sorters, SortOrder} from "@/views/paissa/sorters";
 import SortIcon from "@/views/paissa/SortIcon.vue";
@@ -256,7 +257,7 @@ onMounted(() => {
           <th>
             <span class="icon-text">
               <span>Ward</span>
-              <FilterIcon
+              <FilterIconGrid
                 class="ml-1"
                 :options="filters.wards.options"
                 :selected="getSelectedFilterOptions('wards')"
@@ -267,7 +268,7 @@ onMounted(() => {
           <th>
             <span class="icon-text">
               <span>Plot</span>
-              <FilterIcon
+              <FilterIconGrid
                 class="ml-1"
                 :options="filters.plots.options"
                 :selected="getSelectedFilterOptions('plots')"

--- a/src/views/paissa/WorldView.vue
+++ b/src/views/paissa/WorldView.vue
@@ -372,8 +372,8 @@ onMounted(() => {
           :key="[plot.world_id, plot.district_id, plot.ward_number, plot.plot_number].toString()"
         >
           <td>{{ client.districtName(plot.district_id) }}</td>
-          <td>{{ plot.ward_number + 1 }}</td>
-          <td>{{ plot.plot_number + 1 }}</td>
+          <td>Ward {{ plot.ward_number + 1 }}</td>
+          <td>Plot {{ plot.plot_number + 1 }}</td>
           <td>{{ utils.sizeStr(plot.size) }}</td>
           <td>{{ plot.price.toLocaleString() }}</td>
           <td>

--- a/src/views/paissa/filters.ts
+++ b/src/views/paissa/filters.ts
@@ -84,8 +84,8 @@ export const filters: {[id: string]: FilterParams<number>} = {
 };
 
 function generateOptionSequence(untilNumber: number): FilterOption<number>[] {
-  return [...Array(untilNumber).keys()].map(i => ({
+  return [...Array(untilNumber).keys()].map((i) => ({
     label: `${i + 1}`,
     value: i,
-  }))
+  }));
 }

--- a/src/views/paissa/filters.ts
+++ b/src/views/paissa/filters.ts
@@ -2,6 +2,9 @@ import type {PlotState} from "@/views/paissa/client";
 import {HouseSize, LottoPhase, PurchaseSystem} from "@/views/paissa/types";
 import {isLottery, isUnknownOrOutdatedPhase} from "@/views/paissa/utils";
 
+const maxWardNumber = 30;
+const maxPlotNumber = 60;
+
 export interface FilterOption<T> {
   label: string;
   value: T;
@@ -25,6 +28,18 @@ export const filters: {[id: string]: FilterParams<number>} = {
     ],
     strategy(values: number[]): (plot: PlotState) => boolean {
       return (plot: PlotState) => values.includes(plot.district_id);
+    },
+  },
+  wards: {
+    options: generateOptionSequence(maxWardNumber),
+    strategy(values: number[]): (plot: PlotState) => boolean {
+      return (plot: PlotState) => values.includes(plot.ward_number);
+    },
+  },
+  plots: {
+    options: generateOptionSequence(maxPlotNumber),
+    strategy(values: number[]): (plot: PlotState) => boolean {
+      return (plot: PlotState) => values.includes(plot.plot_number);
     },
   },
   sizes: {
@@ -67,3 +82,10 @@ export const filters: {[id: string]: FilterParams<number>} = {
     },
   },
 };
+
+function generateOptionSequence(untilNumber: number): FilterOption<number>[] {
+  return [...Array(untilNumber).keys()].map(i => ({
+    label: `${i + 1}`,
+    value: i,
+  }))
+}


### PR DESCRIPTION
This PR:
* Separates `Address` into 3 separate columns: `District`, `Ward`, and `Plot`
* Adds the corresponding filters for `Ward` and `Plot`
* Implements `FilterIconGrid` component  for `Ward` and `Plot` dropdown since they have a lot of items

### Preview
* Temp Site: [https://d5e5a4d0.2023-12-30-paissa-db.pages.dev/paissa](https://d5e5a4d0.2023-12-30-paissa-db.pages.dev/paissa?world=80&plots=19&plots=49&plots=17&plots=47&plots=2&plots=32&plots=25&plots=24&plots=55&plots=54)

* `FilterIconGrid` on Plots:
![Screenshot 2023-12-30 at 3 37 18 PM](https://github.com/zhudotexe/zhu.codes/assets/25855364/c4a2a462-d4d3-4d54-b5be-fe15a6488868)

* `FilterIconGrid` on too little results — `FilterIcon` would be too long and clips/overflows into the page footer
![Screenshot 2023-12-30 at 3 37 34 PM](https://github.com/zhudotexe/zhu.codes/assets/25855364/9a60efde-1641-4568-a559-58d2b3cccc00)

### Notes
* When new wards are added, `maxWardNumber` needs to be bumped manually
  * The experience degradation is pretty minor though: users just can't filter through the UI  
     The results/entries in the new wards would still be shown
